### PR TITLE
update kibana version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ fi
 if [ -f "$ENV_DIR/DOWNLOAD_URL" ]; then
   DOWNLOAD_URL=$(cat $ENV_DIR/DOWNLOAD_URL)
 else
-  DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-6.6.1-linux-x86_64.tar.gz"
+  DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-6.8.6-linux-x86_64.tar.gz"
 fi
 
 KIBANA_PACKAGE=${DOWNLOAD_URL##*/}

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ This buildpack downloads and installs Kibana into a Scalingo app image.
 
 ## Compatibility
 
-Tested against Kibana 5.5.0 - ES 5.5.0
+Tested against Kibana 6.8.6 - ES 6.8.6
 
 ## Usage
 
@@ -72,4 +72,4 @@ longer directly reachable from the Internet.
 
 ## Extra configuration
 
-* `DOWNLOAD_URL`: Source of the kibana archive, default is: `https://artifacts.elastic.co/downloads/kibana/kibana-5.5.0-linux-x86_64.tar.gz`
+* `DOWNLOAD_URL`: Source of the kibana archive, default is: `https://artifacts.elastic.co/downloads/kibana/kibana-6.8.6-linux-x86_64.tar.gz`


### PR DESCRIPTION
Current elasticsearch version for scalingo is 6.8.6
I update the kibana version to match this value to prevent errors.