### PR TITLE
fix(nginx): bucket is now on GRA

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -119,7 +119,7 @@ echo "-----> Installing reverse proxy for authentication"
 $mkdir "${BUILD_DIR}/vendor/nginx"
 
 NGINX_SWIFT_BUCKET=${NGINX_BP_SWIFT_BUCKET:-scalingo-php-buildpack}
-NGINX_SWIFT_BASE_URL=${NGINX_BP_SWIFT_URL:-https://storage.sbg.cloud.ovh.net/v1/AUTH_be65d32d71a6435589a419eac98613f2}
+NGINX_SWIFT_BASE_URL=${NGINX_BP_SWIFT_URL:-https://storage.gra.cloud.ovh.net/v1/AUTH_be65d32d71a6435589a419eac98613f2}
 NGINX_SWIFT_URL="${NGINX_SWIFT_BASE_URL}/${NGINX_SWIFT_BUCKET}/${STACK}"
 SEMVER_SERVER="https://semver.scalingo.io"
 DEFAULT_NGINX=$(curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}")


### PR DESCRIPTION
This commit on the PHP buildpack (https://github.com/Scalingo/php-buildpack/commit/4ce700ff) changed the location of the Nginx Swift bucket in an emergency due to OVH fire. We forgot to update this buildpack.