### PR TITLE
release(kibana): 6.8.23 is the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This buildpack downloads and installs Kibana into a Scalingo app image.
 
 ## Compatibility
 
-Tested against Kibana 5.5.0 - ES 5.5.0
+Tested against Kibana 6.8.23 - ES 6.8.23
 
 ## Usage
 
@@ -73,4 +73,5 @@ longer directly reachable from the Internet.
 
 ## Extra configuration
 
-* `DOWNLOAD_URL`: Source of the kibana archive, default is: `https://artifacts.elastic.co/downloads/kibana/kibana-5.5.0-linux-x86_64.tar.gz`
+* `KIBANA_VERSION`: Kibana version to install (e.g. `6.8.23`)
+* `DOWNLOAD_URL`: Source of the kibana archive, default is: `https://artifacts.elastic.co/downloads/kibana/kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz`

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,8 @@ fi
 if [ -f "$ENV_DIR/DOWNLOAD_URL" ]; then
   DOWNLOAD_URL=$(cat $ENV_DIR/DOWNLOAD_URL)
 else
-  DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-6.8.21-linux-x86_64.tar.gz"
+  KIBANA_VERSION=${KIBANA_VERSION:-6.8.23}
+  DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-oss-${KIBANA_VERSION}-linux-x86_64.tar.gz"
 fi
 
 KIBANA_PACKAGE=${DOWNLOAD_URL##*/}


### PR DESCRIPTION
Elasticsearch being not yet available on Scalingo, we can't completely fix the related issue. But the latest version of Elasticsearch is 6.8.23, let's use this version of Kibana.

Related to #10