### PR TITLE
fix(nginx) Invalid ELASTICSEARCH_AUTH generation on credentials that are longer than 76 chars in base 64

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -162,7 +162,7 @@ mkfifo \$pmsgr
 eval \$(echo \$ELASTICSEARCH_URL | sed -r 's/(https?:\/\/)((.*):(.*)@){0,1}(.*)/ELASTICSEARCH_URL=\1\5 \nELASTICSEARCH_USER=\3 \nELASTICSEARCH_PASSWORD=\4/')
 
 if [[ -n "\$ELASTICSEARCH_USER" && -n "\$ELASTICSEARCH_PASSWORD" ]] ; then
-  export ELASTICSEARCH_AUTH=\$(echo -n \$ELASTICSEARCH_USER:\$ELASTICSEARCH_PASSWORD | base64)
+  export ELASTICSEARCH_AUTH=\$(echo -n \$ELASTICSEARCH_USER:\$ELASTICSEARCH_PASSWORD | base64 --wrap=0)
 fi
 
 erb "\$basedir/vendor/nginx/conf/nginx.conf.erb" > "\$basedir/vendor/nginx/conf/nginx.conf"


### PR DESCRIPTION
Fix #22